### PR TITLE
feat(luma): generic experience trust band on home page

### DIFF
--- a/luma-pediatrics/src/pages/index.astro
+++ b/luma-pediatrics/src/pages/index.astro
@@ -199,6 +199,19 @@ const trustPhotos = [
   </section>
 
   <!-- ====================================================================
+       EXPERIENCE — generic trust band (employer-safe pre-launch)
+       ==================================================================== -->
+  <section class="py-10 md:py-12 bg-[var(--color-sage-light)]/40 border-y border-[var(--color-border-soft)] reveal">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <p class="text-base md:text-lg text-luma-ink/85 leading-relaxed">
+        <Icon name="lucide:award" class="inline w-5 h-5 -mt-1 text-luma-gold" />
+        {' '}<strong class="font-semibold">{SITE.provider.experienceLine}</strong>
+        {' '}Board-certified, evidence-based, and built on long relationships with the families we serve.
+      </p>
+    </div>
+  </section>
+
+  <!-- ====================================================================
        WAITLIST — pre-launch founding-families capture
        ==================================================================== -->
   <section class="py-16 md:py-20 reveal">

--- a/luma-pediatrics/src/site.config.ts
+++ b/luma-pediatrics/src/site.config.ts
@@ -33,8 +33,15 @@ export const SITE = {
     name: 'Our pediatrician',
     shortName: 'Our pediatrician',
     role: 'Board-certified pediatrician',
+    /**
+     * Generic, employer-safe trust signal usable while showProviderProfile = false.
+     * No name, no current employer, no specific year count tied to a public CV.
+     * Update to specifics (e.g., "10+ years") only when ready to attribute publicly.
+     */
+    experienceLine:
+      'Backed by years of pediatric experience caring for North Texas families.',
     intro:
-      'Luma Pediatrics is led by a board-certified pediatrician with a warm, family-centered approach and a deep commitment to helping children feel safe, seen, and supported. Provider profile will be shared closer to opening day.',
+      'Luma Pediatrics is led by a board-certified pediatrician with over a decade of experience caring for North Texas families — a warm, family-centered approach and a deep commitment to helping children feel safe, seen, and supported. Full provider profile will be shared closer to opening day.',
     education: [],
     personal: '',
     languages: [],


### PR DESCRIPTION
Adds an employer-safe trust signal above the waitlist on the home page. No name, no current employer, no scraped third-party reviews. Real Google / US News reviews deferred until launch (clean Google Business Profile + FTC attribution + provider can be named publicly).