### PR TITLE
feat(luma): warmer 'Join the Luma family' CTAs + Text button on mobile bar

### DIFF
--- a/luma-pediatrics/src/components/MobileCTABar.astro
+++ b/luma-pediatrics/src/components/MobileCTABar.astro
@@ -1,8 +1,8 @@
 ---
 /**
  * Sticky mobile CTA bar — fixed to the bottom of the viewport on small screens.
- * Provides one-tap Call and one-tap Book buttons. Hidden on md+ where the
- * header already exposes both actions prominently.
+ * Provides one-tap Call, Text, and Book buttons. Hidden on md+ where the
+ * header already exposes booking prominently.
  */
 import { Icon } from 'astro-icon/components';
 import { SITE } from '../site.config';
@@ -15,15 +15,23 @@ import { SITE } from '../site.config';
   <div class="flex gap-2 rounded-full bg-[var(--color-card)]/95 backdrop-blur ring-1 ring-[var(--color-border-soft)] shadow-[0_-6px_24px_-12px_rgba(11,29,58,0.25)] p-1.5">
     <a
       href={SITE.contact.phoneHref}
-      class="flex-1 inline-flex items-center justify-center gap-2 min-h-11 px-4 rounded-full text-[var(--color-primary)] no-underline font-semibold border border-[var(--color-border-soft)]"
+      class="flex-1 inline-flex items-center justify-center gap-1.5 min-h-11 px-3 rounded-full text-[var(--color-primary)] no-underline font-semibold text-sm border border-[var(--color-border-soft)]"
       aria-label={`Call ${SITE.name}`}
     >
       <Icon name="lucide:phone" class="w-4 h-4" stroke-width="1.8" aria-hidden="true" />
       Call
     </a>
     <a
+      href={SITE.contact.smsHref}
+      class="flex-1 inline-flex items-center justify-center gap-1.5 min-h-11 px-3 rounded-full text-[var(--color-primary)] no-underline font-semibold text-sm border border-[var(--color-border-soft)]"
+      aria-label={`Text ${SITE.name}`}
+    >
+      <Icon name="lucide:message-circle" class="w-4 h-4" stroke-width="1.8" aria-hidden="true" />
+      Text
+    </a>
+    <a
       href={SITE.bookingUrl}
-      class="flex-1 inline-flex items-center justify-center gap-2 min-h-11 px-4 rounded-full bg-[var(--color-primary)] text-white no-underline font-semibold"
+      class="flex-1 inline-flex items-center justify-center gap-1.5 min-h-11 px-3 rounded-full bg-[var(--color-primary)] text-white no-underline font-semibold text-sm"
       aria-label="Book an appointment (opens healow)"
     >
       <Icon name="lucide:calendar-check" class="w-4 h-4" stroke-width="1.8" aria-hidden="true" />

--- a/luma-pediatrics/src/components/WaitlistForm.astro
+++ b/luma-pediatrics/src/components/WaitlistForm.astro
@@ -16,10 +16,10 @@ const w3fConfigured =
 
 const action = w3fConfigured ? 'https://api.web3forms.com/submit' : SITE.contact.emailHref;
 
-const headline = title ?? 'Be among the first families at Luma';
+const headline = title ?? 'Come join the Luma family';
 const intro =
   blurb ??
-  `We're opening ${SITE.openingWindow} in ${SITE.locationShort}. Join the founding-families list and we'll reach out the moment we're booking appointments — no spam, ever.`;
+  `We're opening ${SITE.openingWindow} in ${SITE.locationShort}. Drop your info and we'll save you a spot — you'll be the first to hear when we open our doors. No spam, just a warm hello when we're ready for you.`;
 
 const isHero = variant === 'hero';
 ---
@@ -98,7 +98,7 @@ const isHero = variant === 'hero';
         class="inline-flex items-center justify-center gap-2 min-h-11 px-6 rounded-full bg-[var(--color-primary)] text-white font-semibold hover:brightness-110 focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 outline-none"
       >
         <Icon name="lucide:send" class="w-4 h-4" stroke-width="1.8" aria-hidden="true" />
-        Join the waitlist
+        Join the Luma family
       </button>
       <p class="text-xs text-[var(--color-muted-foreground)]">
         We'll only use your info to share opening news. Unsubscribe anytime.

--- a/luma-pediatrics/src/pages/pediatrician/[city].astro
+++ b/luma-pediatrics/src/pages/pediatrician/[city].astro
@@ -46,7 +46,7 @@ const description = `Luma Pediatrics — a warm, evidence-based pediatric clinic
       )}
       <div class="flex flex-wrap justify-center gap-3">
         <Button href="#waitlist" variant="primary">
-          Join the founding-families list
+          Join the Luma family
         </Button>
         <Button href="/about/" variant="secondary">About Luma</Button>
       </div>

--- a/luma-pediatrics/src/site.config.ts
+++ b/luma-pediatrics/src/site.config.ts
@@ -58,6 +58,7 @@ export const SITE = {
   contact: {
     phone: '(555) 555-0100',
     phoneHref: 'tel:+15555550100',
+    smsHref: 'sms:+15555550100',
     email: 'hello@lumapediatrics.com',
     emailHref: 'mailto:hello@lumapediatrics.com',
   },


### PR DESCRIPTION
Implements items #1 and #4 from the yourmckinneydentist.com inspiration audit.

#1 Warmer CTAs: waitlist headline + button + city pages now say 'Join the Luma family'.
#4 Mobile sticky CTA bar: Call / Text / Book (was Call / Book). New SMS link uses sms: protocol on office number.

Build verified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>