### PR TITLE
Polish: professional, evidence-based tone + consistency fixes

### DIFF
--- a/luma-pediatrics/astro.config.mjs
+++ b/luma-pediatrics/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
           'handshake',
           'arrow-up-right',
           'message-circle',
+          'siren',
         ],
       },
     }),

--- a/luma-pediatrics/src/components/WaitlistForm.astro
+++ b/luma-pediatrics/src/components/WaitlistForm.astro
@@ -16,10 +16,10 @@ const w3fConfigured =
 
 const action = w3fConfigured ? 'https://api.web3forms.com/submit' : SITE.contact.emailHref;
 
-const headline = title ?? 'Come join the Luma family';
+const headline = title ?? 'Join the founding-families list';
 const intro =
   blurb ??
-  `We're opening ${SITE.openingWindow} in ${SITE.locationShort}. Drop your info and we'll save you a spot — you'll be the first to hear when we open our doors. No spam, just a warm hello when we're ready for you.`;
+  `Luma Pediatrics opens ${SITE.openingWindow} in ${SITE.locationShort}. Share your details and we'll notify you the moment scheduling opens — and answer any early questions about establishing care.`;
 
 const isHero = variant === 'hero';
 ---
@@ -98,7 +98,7 @@ const isHero = variant === 'hero';
         class="inline-flex items-center justify-center gap-2 min-h-11 px-6 rounded-full bg-[var(--color-primary)] text-white font-semibold hover:brightness-110 focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 outline-none"
       >
         <Icon name="lucide:send" class="w-4 h-4" stroke-width="1.8" aria-hidden="true" />
-        Join the Luma family
+        Join the waitlist
       </button>
       <p class="text-xs text-[var(--color-muted-foreground)]">
         We'll only use your info to share opening news. Unsubscribe anytime.

--- a/luma-pediatrics/src/data/cities.ts
+++ b/luma-pediatrics/src/data/cities.ts
@@ -42,7 +42,7 @@ export const CITIES: CityPage[] = [
       'Frisco families — Luma Pediatrics is a short drive east, offering longer visits and same-day sick appointments.',
     landmarks: ['The Star', 'Stonebriar', 'Phillips Creek Ranch', 'Frisco ISD schools'],
     whyLuma:
-      "Frisco parents tell us they want a pediatrician who actually listens. Our model — fewer patients per provider, longer visit times, direct provider access — is built for that.",
+      'Frisco families seeking a pediatrician focused on continuity and unhurried visits will find Luma a short drive east — with longer appointment times, direct access to your provider, and same-day availability for sick visits.',
   },
   {
     slug: 'allen',
@@ -53,7 +53,7 @@ export const CITIES: CityPage[] = [
       'Allen families can reach Luma Pediatrics in under fifteen minutes via US-75 — with same-day sick visits and gentle, unhurried care.',
     landmarks: ['Watters Creek', 'Twin Creeks', 'Allen ISD schools', 'Allen Premium Outlets'],
     whyLuma:
-      "We see a lot of Allen families because we're easy to reach off 75 and we never double-book. When your child is sick, we get you in the same day — no triage runaround.",
+      'Allen families can reach Luma in under fifteen minutes via US-75. Our scheduling model preserves same-day availability for sick visits, and routine appointments are designed to run on time.',
   },
   {
     slug: 'prosper',
@@ -64,6 +64,6 @@ export const CITIES: CityPage[] = [
       'Prosper families — Luma Pediatrics offers warm, evidence-based care just down 380, with newborn rounds at BSW McKinney.',
     landmarks: ['Windsong Ranch', 'Light Farms', 'Prosper ISD schools', 'Gates of Prosper'],
     whyLuma:
-      "Many Prosper families deliver at BSW McKinney — where we'll round on your newborn before you even leave the hospital. From there, the transition to our clinic is seamless.",
+      'For Prosper families delivering at Baylor Scott & White Medical Center – McKinney, Luma provides in-hospital newborn rounds and a seamless transition to outpatient pediatric care.',
   },
 ];

--- a/luma-pediatrics/src/pages/about.astro
+++ b/luma-pediatrics/src/pages/about.astro
@@ -82,7 +82,7 @@ const values = [
           of warmth that turns a clinic into a place your kids actually like going.
         </p>
         <p>
-          Our practice is physician-led, with a small, focused team.
+          Our practice is physician-led and independently owned.
           <a href="/new-patients">See accepted insurance plans →</a>
         </p>
       </div>

--- a/luma-pediatrics/src/pages/contact.astro
+++ b/luma-pediatrics/src/pages/contact.astro
@@ -102,7 +102,7 @@ import { SITE } from '../site.config';
                   <div><span class="font-semibold">{day}</span> · {time}</div>
                 ))}
                 <p class="mt-2 text-sm text-[var(--color-foreground)]/70 italic">
-                  Early weekday opens and Saturday mornings — built around your workday.
+                  Extended weekday hours and Saturday mornings to accommodate working families.
                 </p>
               </div>
             </div>

--- a/luma-pediatrics/src/pages/index.astro
+++ b/luma-pediatrics/src/pages/index.astro
@@ -3,7 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Button from '../components/Button.astro';
 import StarDivider from '../components/StarDivider.astro';
 import SageWave from '../components/SageWave.astro';
-import FeatureTrio from '../components/FeatureTrio.astro';
 import SparkleField from '../components/SparkleField.astro';
 import WaitlistForm from '../components/WaitlistForm.astro';
 import { Icon } from 'astro-icon/components';
@@ -11,10 +10,65 @@ import { SITE } from '../site.config';
 import { featuredServices as services } from '../data/services';
 import Picture from '../components/Picture.astro';
 
-const testimonials = [
-  { quote: "Luma Pediatrics has been amazing with our kids. The care, kindness, and attention are unmatched.", author: 'North Dallas Parent' },
-  { quote: "They never make us feel rushed. Our toddler actually looks forward to her check-ups now.",         author: 'Maya, mom of a 3-year-old' },
-  { quote: "Same-day sick visit when our son had a fever, and the doctor called that evening to check on him.", author: 'Daniel, dad of two' },
+const promises = [
+  {
+    icon: 'lucide:clock',
+    title: 'Unhurried, attentive visits',
+    body: 'Longer appointment times by design, so every question is heard and every concern is addressed with care.',
+  },
+  {
+    icon: 'lucide:users',
+    title: 'Continuity of care',
+    body: 'Your child sees the same pediatrician at every visit — building a trusted relationship that grows with your family.',
+  },
+  {
+    icon: 'lucide:heart',
+    title: 'Partnership with parents',
+    body: 'Clear guidance, honest answers, and a clinical team that listens. We support the decisions you make for your child.',
+  },
+];
+
+const expectations = [
+  {
+    icon: 'lucide:clock',
+    title: 'Thoughtful, unhurried visits',
+    body: 'Appointment times are intentionally longer so every concern is examined carefully and every question receives a complete answer.',
+  },
+  {
+    icon: 'lucide:calendar',
+    title: 'Schedules that work for families',
+    body: 'Weekday hours from 7:30 am and Saturday mornings make it easier to schedule routine and same-day visits without disrupting school or work.',
+  },
+  {
+    icon: 'lucide:message-circle',
+    title: 'Direct, secure communication',
+    body: 'Reach our clinical team by phone, secure text, or patient portal during office hours — without phone trees or long hold times.',
+  },
+  {
+    icon: 'lucide:users',
+    title: 'Continuity with your pediatrician',
+    body: 'Your child sees the same board-certified pediatrician at every visit, supporting accurate diagnosis, consistent care, and a trusted long-term relationship.',
+  },
+  {
+    icon: 'lucide:shield-check',
+    title: 'Evidence-based pediatric medicine',
+    body: 'Care guided by current AAP and CDC recommendations, delivered with clear explanations so families understand every decision.',
+  },
+  {
+    icon: 'lucide:hospital',
+    title: 'Newborn rounds at BSW McKinney',
+    body: 'In-hospital newborn visits at Baylor Scott & White Medical Center – McKinney, ensuring a seamless transition from the hospital to your pediatric home.',
+  },
+  {
+    icon: 'lucide:siren',
+    title: 'Pediatric specialty access',
+    body: "When advanced care is needed, we coordinate referrals to North Texas's leading children's hospitals and pediatric subspecialists.",
+  },
+  {
+    icon: 'lucide:handshake',
+    title: 'Complimentary Meet & Greet',
+    body: 'Tour the practice and meet your pediatrician before establishing care — an opportunity to ensure Luma is the right fit for your family.',
+  },
 ];
 
 const trustPhotos = [
@@ -82,9 +136,9 @@ const trustPhotos = [
             Where your child's health shines.
           </p>
           <p class="mt-4 text-base md:text-lg text-[var(--color-foreground)]/80 max-w-xl mx-auto lg:mx-0 leading-relaxed">
-            Hi — we're a small, family-run pediatric clinic opening in {SITE.locationShort.split(',')[0]}.
-            We take fewer patients per provider so we can take more time with yours.
-            Newborns to teens, well checks to same-day sick visits — we're so glad you found us.
+            Luma Pediatrics is an independent pediatric practice opening in {SITE.locationShort.split(',')[0]},
+            offering comprehensive care for newborns through young adulthood —
+            from well-child visits and immunizations to same-day sick care.
           </p>
 
           <div class="mt-6 flex flex-wrap justify-center lg:justify-start gap-3">
@@ -116,30 +170,21 @@ const trustPhotos = [
   </section>
 
   <!-- ====================================================================
-       FEATURE TRIO STRIP — on sage band (matches brand marketing footer)
-       ==================================================================== -->
-  <section class="bg-[var(--color-sage-light)]">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
-      <FeatureTrio onSage />
-    </div>
-  </section>
-
-  <!-- ====================================================================
        TRUST-BUILDING PHOTO STRIP — warm faces and safe, happy care moments.
        ==================================================================== -->
   <section class="trust-gallery py-20 md:py-28 reveal">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid gap-10 lg:grid-cols-[0.82fr_1.18fr] items-end mb-12">
         <div>
-          <span class="eyebrow eyebrow-sun">Warm, safe, happy</span>
+          <span class="eyebrow eyebrow-sun">Warm, safe, attentive</span>
           <h2 class="mt-5 text-4xl md:text-6xl tracking-tight">
-            Care that feels reassuring from the first hello.
+            A welcoming environment for every visit.
           </h2>
         </div>
         <p class="text-lg text-[var(--color-foreground)]/78 leading-relaxed max-w-2xl lg:ml-auto">
-          We know clinics can feel cold and rushed. We've built the opposite — a calm, bright
-          space where your child gets to know us, and we get to know them. Real smiles.
-          Unhurried visits. The kind of place kids actually look forward to.
+          Our practice is designed to feel calm, bright, and reassuring — a place where children
+          are comfortable and parents feel supported. Thoughtful, unhurried visits delivered with
+          the warmth and professionalism your family deserves.
         </p>
       </div>
 
@@ -210,7 +255,7 @@ const trustPhotos = [
       <p class="text-base md:text-lg text-luma-ink/85 leading-relaxed">
         <Icon name="lucide:award" class="inline w-5 h-5 -mt-1 text-luma-gold" />
         {' '}<strong class="font-semibold">{SITE.provider.experienceLine}</strong>
-        {' '}Board-certified, evidence-based, and built on long relationships with the families we serve.
+        {' '}Board-certified pediatric care, grounded in current AAP and CDC clinical guidelines.
       </p>
     </div>
   </section>
@@ -222,96 +267,23 @@ const trustPhotos = [
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-2xl mx-auto text-center mb-12">
         <span class="eyebrow">What to expect</span>
-        <h2 class="mt-5 text-3xl md:text-5xl tracking-tight">A visit that actually feels different.</h2>
+        <h2 class="mt-5 text-3xl md:text-5xl tracking-tight">Comprehensive, evidence-based pediatric care.</h2>
         <p class="mt-5 text-lg text-[var(--color-foreground)]/78 leading-relaxed">
-          We've all been to clinics that feel like a conveyor belt. Here's how we're doing it differently.
+          A clinical model built around continuity, accessibility, and the highest standards of
+          modern pediatric medicine.
         </p>
       </div>
 
       <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:clock" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">You won't feel rushed</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            We block longer visit times on purpose. That means we get to actually answer your
-            questions — even the ones you weren't sure how to ask.
-          </p>
-        </article>
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:phone" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">Hours that fit your workday</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            Parents work — we get it. We open at 7:30 am on weekdays and are here
-            Saturday mornings, so well checks and sick visits don't have to mean
-            burning a PTO day. Call in the morning, see us the same day.
-          </p>
-        </article>
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:message-circle" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">Text us — really</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            Quick question about a rash, a refill, or whether to come in? Send us a text
-            during office hours. No phone tree, no hold music — just a real reply from
-            people who know your child.
-          </p>
-        </article>
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:users" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">Same provider, every time</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            Your child sees the same pediatrician at every visit. We learn what's normal for
-            them, what makes them anxious, what makes them laugh. That continuity is the care.
-          </p>
-        </article>
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:heart" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">No question is too small</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            New parent, second-time parent, fifth-time parent — kids surprise us all.
-            Ask us anything. We'd rather hear from you than have you Google it at 2am.
-          </p>
-        </article>
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:hospital" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">From the hospital, home</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            Delivering at Baylor Scott & White McKinney? We'll meet your baby at the bedside —
-            a smooth handoff from the hospital straight to your pediatric home.
-          </p>
-        </article>
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:shield-check" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">Backed by a children's ER, 24/7</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            When something serious happens, you need pediatric expertise — not a general
-            ER. We coordinate directly with a dedicated children's hospital and ER nearby,
-            so your child is always seen by people who treat kids first.
-          </p>
-        </article>
-        <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
-          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
-            <Icon name="lucide:handshake" class="w-6 h-6" stroke-width="1.6" />
-          </span>
-          <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">Meet us before you commit</h3>
-          <p class="text-[var(--color-foreground)]/80 leading-relaxed">
-            Choosing a pediatrician is a big call. Come by for a free Meet & Greet — tour the
-            space, meet your pediatrician, ask the questions that matter. No pressure.
-          </p>
-        </article>
+        {expectations.map(({ icon, title, body }) => (
+          <article class="rounded-[var(--radius-card)] bg-[var(--color-card)] p-7 card-lift">
+            <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-[var(--color-muted)] text-[var(--color-primary)] mb-4">
+              <Icon name={icon} class="w-6 h-6" stroke-width="1.6" aria-hidden="true" />
+            </span>
+            <h3 class="text-xl font-semibold mb-2" style="font-family: var(--font-display);">{title}</h3>
+            <p class="text-[var(--color-foreground)]/80 leading-relaxed">{body}</p>
+          </article>
+        ))}
       </div>
     </div>
   </section>
@@ -347,31 +319,30 @@ const trustPhotos = [
   </section>
 
   <!-- ====================================================================
-       TESTIMONIALS
+       OUR PROMISE — values-led block (replaces testimonials pre-launch;
+       we'll add real, attributed reviews after launch with consent).
        ==================================================================== -->
-  <section aria-label="Parent testimonials" class="py-20 md:py-28 reveal relative navy-campaign">
+  <section aria-label="Our promise to your family" class="py-20 md:py-28 reveal relative navy-campaign">
     <SparkleField count={8} />
     <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="max-w-2xl mx-auto text-center mb-14">
-        <span class="eyebrow eyebrow-sun">From our families</span>
-        <h2 class="mt-5 text-3xl md:text-5xl tracking-tight">What parents say</h2>
+        <span class="eyebrow eyebrow-sun">Our commitment</span>
+        <h2 class="mt-5 text-3xl md:text-5xl tracking-tight text-white">The standards we hold ourselves to</h2>
+        <p class="mt-5 text-white/85 leading-relaxed text-lg">
+          As a new practice, we earn families' trust through the standard of care we provide.
+          These are the commitments you can count on at every visit.
+        </p>
       </div>
 
       <div class="grid gap-6 md:grid-cols-3">
-        {testimonials.map(({ quote, author }) => (
-          <figure class="card-lift navy-card rounded-[var(--radius-card)] p-8">
-            <div class="flex gap-1 text-[var(--color-sun)] mb-4" aria-label="5 out of 5 stars">
-              {Array.from({ length: 5 }).map(() => (
-                <Icon name="lucide:star" class="w-4 h-4 fill-current" stroke-width="1.4" aria-hidden="true" />
-              ))}
-            </div>
-            <blockquote class="text-white text-lg leading-relaxed" style="font-family: var(--font-display);">
-              <p class="italic">"{quote}"</p>
-            </blockquote>
-            <figcaption class="mt-5 text-sm text-[var(--color-sun)]">
-              — {author}
-            </figcaption>
-          </figure>
+        {promises.map(({ icon, title, body }) => (
+          <article class="card-lift navy-card rounded-[var(--radius-card)] p-8">
+            <span class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-white/15 text-[var(--color-sun)] mb-5" aria-hidden="true">
+              <Icon name={icon} class="w-6 h-6" stroke-width="1.6" />
+            </span>
+            <h3 class="text-xl font-semibold text-white mb-3" style="font-family: var(--font-display);">{title}</h3>
+            <p class="text-white/85 leading-relaxed">{body}</p>
+          </article>
         ))}
       </div>
     </div>

--- a/luma-pediatrics/src/pages/new-patients.astro
+++ b/luma-pediatrics/src/pages/new-patients.astro
@@ -110,6 +110,7 @@ const bringList = [
   <section class="py-16 md:py-20 bg-[var(--color-muted)] reveal relative overflow-hidden">
     <PageDecor variant="soft" sparkles={8} />
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+        <div class="grid gap-10 md:grid-cols-2">
         <div>
           <span class="eyebrow">What to bring</span>
           <h2 class="mt-5 text-2xl md:text-3xl font-extrabold tracking-tight">A quick checklist</h2>

--- a/luma-pediatrics/src/pages/pediatrician/[city].astro
+++ b/luma-pediatrics/src/pages/pediatrician/[city].astro
@@ -46,7 +46,7 @@ const description = `Luma Pediatrics — a warm, evidence-based pediatric clinic
       )}
       <div class="flex flex-wrap justify-center gap-3">
         <Button href="#waitlist" variant="primary">
-          Join the Luma family
+          Join the waitlist
         </Button>
         <Button href="/about/" variant="secondary">About Luma</Button>
       </div>

--- a/luma-pediatrics/src/pages/services.astro
+++ b/luma-pediatrics/src/pages/services.astro
@@ -21,7 +21,7 @@ import { services } from '../data/services';
         Comprehensive pediatric care — every visit.
       </h1>
       <p class="mt-6 tagline-italic-sage text-lg md:text-xl">
-        From your child's first checkup to their last visit before college.
+        From your child's first checkup through young adulthood.
       </p>
     </div>
   </section>

--- a/luma-pediatrics/src/site.config.ts
+++ b/luma-pediatrics/src/site.config.ts
@@ -41,7 +41,7 @@ export const SITE = {
     experienceLine:
       'Backed by years of pediatric experience caring for North Texas families.',
     intro:
-      'Luma Pediatrics is led by a board-certified pediatrician with over a decade of experience caring for North Texas families — a warm, family-centered approach and a deep commitment to helping children feel safe, seen, and supported. Full provider profile will be shared closer to opening day.',
+      'Luma Pediatrics is led by a board-certified pediatrician with years of experience caring for North Texas families — a warm, family-centered approach and a deep commitment to helping children feel safe, seen, and supported. Full provider profile will be shared closer to opening day.',
     education: [],
     personal: '',
     languages: [],
@@ -106,7 +106,7 @@ export const SITE = {
   /** Professional affiliations / credentials surfaced near the provider bio. */
   affiliations: [
     { icon: 'lucide:shield-check', label: 'Board-Certified Pediatrician' },
-    { icon: 'lucide:award',        label: 'Fellow, American Academy of Pediatrics (AAP)' },
+    { icon: 'lucide:award',        label: 'Member, American Academy of Pediatrics (AAP)' },
     { icon: 'lucide:stethoscope',  label: 'Evidence-based primary pediatric care' },
     { icon: 'lucide:heart',        label: 'Family-centered, all ages welcome' },
   ],


### PR DESCRIPTION
Site-wide copy refresh to convey serious, evidence-based pediatric medicine, plus several accuracy/consistency fixes:

**Tone**
- Removed 3 fabricated testimonials (FTC/ethics)
- Replaced with 'Our commitment' standards-of-care block
- Rewrote 8 'What to expect' cards in a clean, professional voice
- Refined hero, trust-gallery, waitlist, contact, city pages

**Accuracy**
- 'Fellow, AAP' → 'Member, AAP'
- 'over a decade' specificity removed from provider intro
- 'family-run clinic' → 'independent practice'
- 'physician-led, with a small focused team' → 'physician-led and independently owned'
- Removed 'parents tell us…' / 'we see a lot of families…' fabrications on city pages

**Bug**
- new-patients.astro: 'What to bring' + 'Insurance' missing grid wrapper

**Cleanup**
- Removed duplicate FeatureTrio on home (also rendered in footer)
- services.astro subtitle consistent with rest of site
- Added 'siren' to icon allowlist