### PR TITLE
fix(header): desktop Text us link + single-line nav items

### DIFF
--- a/luma-pediatrics/src/components/Header.astro
+++ b/luma-pediatrics/src/components/Header.astro
@@ -24,7 +24,7 @@ const navLinks = SITE.nav.filter((n) => n.href !== '/');
         {navLinks.map(({ href, label }) => (
           <a
             href={href}
-             class="px-3 py-2 rounded-full text-[var(--color-foreground)] no-underline font-medium hover:bg-[rgba(200, 153, 90,0.10)] [transition:background-color_var(--duration-fast)_var(--ease-fluid),color_var(--duration-fast)_var(--ease-fluid)]"
+             class="px-3 py-2 rounded-full text-[var(--color-foreground)] no-underline font-medium whitespace-nowrap hover:bg-[rgba(200, 153, 90,0.10)] [transition:background-color_var(--duration-fast)_var(--ease-fluid),color_var(--duration-fast)_var(--ease-fluid)]"
           >
             {label}
           </a>
@@ -41,18 +41,26 @@ const navLinks = SITE.nav.filter((n) => n.href !== '/');
         </a>
         <a
           href={SITE.contact.phoneHref}
-           class="hidden sm:inline-flex items-center gap-2 px-3 py-2 rounded-full text-[var(--color-foreground)] no-underline font-medium hover:bg-[rgba(200, 153, 90,0.10)] [transition:background-color_var(--duration-fast)_var(--ease-fluid)]"
+           class="hidden sm:inline-flex items-center gap-2 px-3 py-2 rounded-full text-[var(--color-foreground)] no-underline font-medium whitespace-nowrap hover:bg-[rgba(200, 153, 90,0.10)] [transition:background-color_var(--duration-fast)_var(--ease-fluid)]"
           aria-label="Call the office"
         >
           <Icon name="lucide:phone" class="w-4 h-4" stroke-width="1.6" aria-hidden="true" />
           <span class="hidden lg:inline">{SITE.contact.phone}</span>
+        </a>
+        <a
+          href={SITE.contact.smsHref}
+           class="hidden lg:inline-flex items-center gap-2 px-3 py-2 rounded-full text-[var(--color-foreground)] no-underline font-medium whitespace-nowrap hover:bg-[rgba(200, 153, 90,0.10)] [transition:background-color_var(--duration-fast)_var(--ease-fluid)]"
+          aria-label={`Text ${SITE.name}`}
+        >
+          <Icon name="lucide:message-circle" class="w-4 h-4" stroke-width="1.6" aria-hidden="true" />
+          <span>Text us</span>
         </a>
         <!-- Book Appointment → healow (external HIPAA-compliant patient portal).
              On phones the label compresses to "Book" to leave room for the menu toggle. -->
         <Button href={SITE.bookingUrl} variant="primary" ariaLabel="Book an appointment (opens healow)">
           <Icon name="lucide:calendar-check" class="w-4 h-4" stroke-width="1.6" />
           <span class="sm:hidden">Book</span>
-          <span class="hidden sm:inline">Book Appointment</span>
+          <span class="hidden sm:inline whitespace-nowrap">Book Appointment</span>
         </Button>
 
         <button
@@ -88,6 +96,14 @@ const navLinks = SITE.nav.filter((n) => n.href !== '/');
           >
             <Icon name="lucide:phone" class="w-4 h-4" stroke-width="1.8" aria-hidden="true" />
             {SITE.contact.phone}
+          </a>
+          <a
+            href={SITE.contact.smsHref}
+            class="px-2 py-3 rounded-lg text-base text-[var(--color-primary)] no-underline font-semibold inline-flex items-center gap-2"
+            aria-label={`Text ${SITE.name}`}
+          >
+            <Icon name="lucide:message-circle" class="w-4 h-4" stroke-width="1.8" aria-hidden="true" />
+            Text us
           </a>
         </nav>
       </div>


### PR DESCRIPTION
Adds a 'Text us' pill to the desktop header and forces nav labels + phone + Book Appointment to render on a single line.